### PR TITLE
Allow use of candy-api >=0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "getcandy/candy-api": "0.2.*",
+        "getcandy/candy-api": ">=0.2.0",
         "tightenco/ziggy": "^0.6.9"
     },
     "require-dev": {


### PR DESCRIPTION
Allow candy hub to work with 0.2 and 0.3 candy-api, currently cannot install candy-api 0.3 and candy-hub in the same app due to the "0.2.*" limit